### PR TITLE
Feat/pex support parent task

### DIFF
--- a/client/config/headers.go
+++ b/client/config/headers.go
@@ -37,4 +37,6 @@ const (
 	HeaderDragonflyObjectMetaStorageClass = "X-Dragonfly-Object-Meta-Storage-Class"
 	// HeaderDragonflyObjectOperation is used for object storage operation.
 	HeaderDragonflyObjectOperation = "X-Dragonfly-Object-Operation"
+	// HeaderDragonflyForwardedFrom is used to mark http request forwarded from other peers
+	HeaderDragonflyForwardedFrom = "X-Dragonfly-Forwarded-From"
 )

--- a/client/config/headers.go
+++ b/client/config/headers.go
@@ -37,6 +37,6 @@ const (
 	HeaderDragonflyObjectMetaStorageClass = "X-Dragonfly-Object-Meta-Storage-Class"
 	// HeaderDragonflyObjectOperation is used for object storage operation.
 	HeaderDragonflyObjectOperation = "X-Dragonfly-Object-Operation"
-	// HeaderDragonflyForwardedFrom is used to mark http request forwarded from other peers
-	HeaderDragonflyForwardedFrom = "X-Dragonfly-Forwarded-From"
+	// HeaderDragonflyForwardedFor is used to mark http request forwarded from other peers
+	HeaderDragonflyForwardedFor = "X-Dragonfly-Forwarded-For"
 )

--- a/client/daemon/peer/peertask_stream.go
+++ b/client/daemon/peer/peertask_stream.go
@@ -56,6 +56,14 @@ func (req *StreamTaskRequest) TaskID() string {
 	return req.taskID
 }
 
+func (req *StreamTaskRequest) HasParentTask() bool {
+	return req.Range != nil
+}
+
+func (req *StreamTaskRequest) ParentTaskID() string {
+	return idgen.ParentTaskIDV1(req.URL, req.URLMeta)
+}
+
 // StreamTask represents a peer task with stream io for reading directly without once more disk io
 type StreamTask interface {
 	// Start starts the special peer task, return an io.Reader for stream io


### PR DESCRIPTION
### Description

In this pull request, the following changes have been made:

- Added a new custom HTTP header `X-Dragonfly-Forwarded-For` to mark HTTP requests forwarded from other peers.
- Implemented a method to check if a StreamTaskRequest has a parent task.
- Implemented a method to return the ParentTaskID based on the URL and URLMeta in a StreamTaskRequest.
- Adjusted the `MaxIdleConns` setting in the HTTP transport to `1000` for better performance.
- Updated the `download` function in the transport file to handle forwarded requests and avoid infinite forwarding loops by checking the `X-Dragonfly-Forwarded-For` header.
- Added new methods `tryProxyToPeers` and `searchPeers` for proxying requests to peers based on certain conditions.
- Modified the handling of forwarding requests in the `download` function by calling the `tryProxyToPeers` method and setting/clearing the `X-Dragonfly-Forwarded-For` header accordingly.

These changes aim to enhance the forwarding mechanism and prevent infinite request forwarding loops by keeping track of the source of the forwarded requests.

Let me know if you need any more specific details or explanations for the changes made.